### PR TITLE
[ch198] Menu list in the navigation bar isn't centrically aligned

### DIFF
--- a/src/styles/components/_navbar.scss
+++ b/src/styles/components/_navbar.scss
@@ -44,6 +44,7 @@
   }
 
   &__menu-item {
+    position: relative;
     display: none;
     list-style-type: none;
     text-decoration: none;
@@ -57,6 +58,9 @@
     }
 
     &:after {
+      position: absolute;
+      left: 0;
+      right: 0;
       content: '';
       display: block;
       width: 0;


### PR DESCRIPTION
https://app.clubhouse.io/cobda/story/198/menu-list-in-the-navigation-bar-isn-t-centrically-aligned

## Why?

The highlighter pushes the text up so it makes the menu don't align with others.

## Changes

- Makes menu item align with others.

## Screenshot(s)

**Before**
![image](https://user-images.githubusercontent.com/32285869/109954435-eaad2b00-7d13-11eb-854b-f37a9d3d5c95.png)

**After**
![image](https://user-images.githubusercontent.com/32285869/109954523-044e7280-7d14-11eb-81fe-efb6005fc4c1.png)
