### PR TITLE
[ch252] The background image in Sign-up form isn't cover the entire screen

### DIFF
--- a/src/styles/layouts/_layout-authentication.scss
+++ b/src/styles/layouts/_layout-authentication.scss
@@ -18,13 +18,7 @@
   }
 
   @include respond-above('xl') {
-    grid-template-columns: 1fr minmax(rem(1104px), rem(1440px)) 1fr;
     grid-template-rows: map-get($header-height, 'xl') 1fr map-get($footer-height, 'xl');
-    column-gap: rem(48px);
-    grid-template-areas:
-    'header header header'
-    '. main .'
-    'footer footer footer';
   }
 
   & > header {


### PR DESCRIPTION
https://app.clubhouse.io/cobda/story/252/the-background-image-in-sign-up-form-isn-t-cover-the-entire-screen

## Why?

To solve the problem that the background image is blocked by `column-gap` of `grid`.

## Changes

The background image is already covered in the entire section.

## Screenshot(s)

**Before**
<img width="828" alt="Screenshot 2564-03-19 at 16 04 08" src="https://user-images.githubusercontent.com/32285705/111756402-bf5a3c80-88cc-11eb-8d82-27ed77e65101.png">

**After**
<img width="829" alt="Screenshot 2564-03-19 at 16 02 41" src="https://user-images.githubusercontent.com/32285705/111756219-8ae68080-88cc-11eb-9dc1-ef2e1dd15bf2.png">