### PR TITLE
[ch264] Next command not found on the deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,10 @@ FROM node:current-alpine AS runner
 WORKDIR /app
 
 # Copy files from build stage to production stage
-COPY --from=builder /build/package*.json /build/node_modules /build/.next /build/public ./
+COPY --from=builder /build/node_modules ./node_modules
+COPY --from=builder /build/package*.json ./
+COPY --from=builder /build/.next ./.next
+COPY --from=builder /build/public ./public
 
 # Expose the listening port
 EXPOSE 3000


### PR DESCRIPTION
https://app.clubhouse.io/cobda/story/264/next-command-not-found-on-the-deployment

## Why?

When test deploying containerized application on GKE. On the build log, there's an error (next: command not found). Basically, in `dockerfile`, it should copy to separated folders. But now, all the files (without folder) are copied to `./` only one destination.

## Changes

In `dockerfile`, it should copy files from the `builder stage` to separate folders. 

## Screenshot(s)

See a [file changed](https://github.com/Cobda/cobda-web/pull/53/files)